### PR TITLE
Change givie_helper to encrypt params

### DIFF
--- a/app/helpers/givie_helper.rb
+++ b/app/helpers/givie_helper.rb
@@ -1,14 +1,17 @@
 module GivieHelper
-  
+
   def givie_url(donation)
-    "http://kitten-sandwich.herokuapp.com/pingback?" + 
-      "name=#{donation.name}" +
-      "&message=#{donation.comment}" + 
-      "&twitter=#{donation.twitter_handle}" + 
-      "&github=#{donation.github_handle}" +
-      "&gravatar=#{donation.gravatar_url}" +
-      "&homepage=#{donation.homepage}" +
-      "&uid=#{donation.id}"
+    crypt = ActiveSupport::MessageEncryptor.new(ENV['GIVIE_SECRET'])
+    data = crypt.encrypt_and_sign({
+      uid: donation.id.to_s,
+      name: donation.name,
+      message: donation.comment,
+      twitter: donation.twitter_handle,
+      github: donation.github_handle,
+      gravatar: donation.gravatar_url,
+      homepage: donation.homepage,
+    }.to_json)
+
+    "#{ENV['GIVIE_BASE_URL']}/pingback?data=" + data
   end
-  
 end

--- a/spec/helpers/givie_helper_spec.rb
+++ b/spec/helpers/givie_helper_spec.rb
@@ -1,17 +1,40 @@
 require 'spec_helper'
 
 describe GivieHelper do
-
-  it "generates a givie url from a donation" do
-    donation = Donation.new({
+  subject(:generated_url) { helper.givie_url(donation) }
+  let(:donation) {
+    Donation.new({
       id: 3,
-      name: "sara", 
-      comment: "this is a comment", 
-      twitter_handle: "st", 
-      github_handle: "sg", 
+      name: "sara",
+      comment: "this is a comment",
+      twitter_handle: "st",
+      github_handle: "sg",
       email: "sara@regan.com",
-      homepage: "http://www.foo.bar"})
-    expect(helper.givie_url(donation)).to eq("http://kitten-sandwich.herokuapp.com/pingback?name=sara&message=this is a comment&twitter=st&github=sg&gravatar=#{donation.gravatar_url}&homepage=http://www.foo.bar&uid=#{donation.id}")
+      homepage: "http://www.foo.bar"
+    })
+  }
+  before do
+    ENV['GIVIE_SECRET'] = "kitten sandwich is a strange project name"
+    ENV['GIVIE_BASE_URL'] = "http://givie.com"
   end
-  
+
+  it "matches a givie pingback url" do
+    expect(generated_url).to match(/http:\/\/givie.com\/pingback\?data=\w+/)
+  end
+
+  it "passes donation info as encrypted param" do
+    crypt = ActiveSupport::MessageEncryptor.new(ENV['GIVIE_SECRET'])
+    data = crypt.decrypt_and_verify(data_value(generated_url))
+    expect(JSON.parse(data).symbolize_keys).to include({
+      uid:      donation.id.to_s,
+      name:     donation.name,
+      message:  donation.comment,
+      twitter:  donation.twitter_handle,
+      github:   donation.github_handle,
+    })
+  end
+
+  def data_value(givie_url)
+    Rack::Utils.parse_query(URI.parse(givie_url).query)["data"]
+  end
 end


### PR DESCRIPTION
We encrypt the data now with a shared key. This prevents people from tampering.

Not sure if this is the integration we want in the long term for other sites, but it Works For Now™.  :)

@sareg0 @svenfuchs @marcgreenstock
