### PR TITLE
Add encrypted donation params to link

### DIFF
--- a/app/helpers/givie_helper.rb
+++ b/app/helpers/givie_helper.rb
@@ -1,8 +1,8 @@
 module GivieHelper
 
-  def givie_url(donation)
+  def encrypted_givie_params(donation)
     crypt = ActiveSupport::MessageEncryptor.new(ENV['GIVIE_SECRET'])
-    data = crypt.encrypt_and_sign({
+    crypt.encrypt_and_sign({
       uid: donation.id.to_s,
       name: donation.name,
       message: donation.comment,
@@ -11,7 +11,5 @@ module GivieHelper
       gravatar: donation.gravatar_url,
       homepage: donation.homepage,
     }.to_json)
-
-    "http://www.givie.io/pingback?data=" + data
   end
 end

--- a/app/views/donations/confirm_creation.html.slim
+++ b/app/views/donations/confirm_creation.html.slim
@@ -26,8 +26,8 @@ section class="main container"
                   td
                     div.fb-like data-send="false" data-layout="box_count" data-width="50" data-href="http://railsgirlssummerofcode.org/campaign"
                   td
-                    a.givie-logo href="http://www.givie.io/redirect"
-                      img src="#{givie_url(donation)}" height="60px"
+                    a.givie-logo href="https://www.givie.io/redirect?data=#{encrypted_givie_params(donation)}"
+                      img src="https://www.givie.io/pingback?data=#{encrypted_givie_params(donation)}" height="60px"
             #fb-root
 
 

--- a/spec/helpers/givie_helper_spec.rb
+++ b/spec/helpers/givie_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe GivieHelper do
-  subject(:generated_url) { helper.givie_url(donation) }
+  subject { helper.encrypted_givie_params(donation) }
   let(:donation) {
     Donation.new({
       id: 3,
@@ -15,16 +15,11 @@ describe GivieHelper do
   }
   before do
     ENV['GIVIE_SECRET'] = "kitten sandwich is a strange project name"
-    ENV['GIVIE_BASE_URL'] = "http://givie.com"
-  end
-
-  it "matches a givie pingback url" do
-    expect(generated_url).to match(/http:\/\/www.givie.io\/pingback\?data=\w+/)
   end
 
   it "passes donation info as encrypted param" do
     crypt = ActiveSupport::MessageEncryptor.new(ENV['GIVIE_SECRET'])
-    data = crypt.decrypt_and_verify(data_value(generated_url))
+    data = crypt.decrypt_and_verify(subject)
     expect(JSON.parse(data).symbolize_keys).to include({
       uid:      donation.id.to_s,
       name:     donation.name,
@@ -32,9 +27,5 @@ describe GivieHelper do
       twitter:  donation.twitter_handle,
       github:   donation.github_handle,
     })
-  end
-
-  def data_value(givie_url)
-    Rack::Utils.parse_query(URI.parse(givie_url).query)["data"]
   end
 end


### PR DESCRIPTION
So with 3rd party cookies disabled can click on the link and the donation gets created then.

For users who have 3rd party cookies enabled, the pingback image request will work. Givie checks the uid so donations aren't created on Givie twice.
